### PR TITLE
Update php5 to php7

### DIFF
--- a/webstack.pp
+++ b/webstack.pp
@@ -14,17 +14,18 @@ class { 'apache':
 }
 apache::mod { 'rewrite': }
 class {'::apache::mod::php':
+	php_version   => '7.0'
 }
 
-package { 'php5':
+package { 'php7.0':
 	ensure => installed
 }
 
-$php_extensions = ['php7-mcrypt', 'php7-intl', 'php7-mysql', 'php7-sqlite']
+$php_extensions = ['php7.0-mcrypt', 'php7.0-intl', 'php7.0-mysql', 'php7.0-sqlite', 'php7.0-mbstring']
 
 package { $php_extensions:
 	ensure => installed,
-	require => Package['php7']
+	require => Package['php7.0']
 }
 
 package { 'mysql-server':

--- a/webstack.pp
+++ b/webstack.pp
@@ -20,11 +20,11 @@ package { 'php5':
 	ensure => installed
 }
 
-$php_extensions = ['php5-mcrypt', 'php5-intl', 'php5-mysql', 'php5-sqlite']
+$php_extensions = ['php7-mcrypt', 'php7-intl', 'php7-mysql', 'php7-sqlite']
 
 package { $php_extensions:
 	ensure => installed,
-	require => Package['php5']
+	require => Package['php7']
 }
 
 package { 'mysql-server':


### PR DESCRIPTION
Updated all php5 to php7, because php5 is not available in Ubuntu 16.04 repo anymore.
